### PR TITLE
Update version fix vector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,13 @@
     <dependency>
       <groupId>ml.combust.mleap</groupId>
       <artifactId>mleap-runtime_2.11</artifactId>
-      <version>0.13.0</version>
+      <version>0.15.0</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-mllib-local -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-mllib-local_2.11</artifactId>
+      <version>2.4.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/src/test/java/com/amazonaws/sagemaker/dto/SageMakerRequestObjectTest.java
+++ b/src/test/java/com/amazonaws/sagemaker/dto/SageMakerRequestObjectTest.java
@@ -18,10 +18,11 @@ package com.amazonaws.sagemaker.dto;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import java.io.IOException;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
 
 public class SageMakerRequestObjectTest {
 
@@ -80,14 +81,14 @@ public class SageMakerRequestObjectTest {
         Assert.assertEquals(sro.getSchema().getInput().get(0).getName(), "name_1");
         Assert.assertEquals(sro.getSchema().getInput().get(1).getName(), "name_2");
         Assert.assertEquals(sro.getSchema().getInput().get(2).getName(), "name_3");
-        Assert.assertEquals(sro.getSchema().getInput().get(0).getType(), "int");
+        Assert.assertEquals(sro.getSchema().getInput().get(0).getType(), "double");
         Assert.assertEquals(sro.getSchema().getInput().get(1).getType(), "string");
         Assert.assertEquals(sro.getSchema().getInput().get(2).getType(), "double");
         Assert.assertEquals(sro.getSchema().getInput().get(0).getStruct(), "vector");
         Assert.assertEquals(sro.getSchema().getInput().get(1).getStruct(), "basic");
         Assert.assertEquals(sro.getSchema().getInput().get(2).getStruct(), "array");
         Assert.assertEquals(sro.getData(),
-            Lists.newArrayList(Lists.newArrayList(1, 2, 3), "C", Lists.newArrayList(38.0, 24.0)));
+            Lists.newArrayList(Lists.newArrayList(1.0, 2.0, 3.0), "C", Lists.newArrayList(38.0, 24.0)));
         Assert.assertEquals(sro.getSchema().getOutput().getName(), "features");
         Assert.assertEquals(sro.getSchema().getOutput().getType(), "double");
         Assert.assertEquals(sro.getSchema().getOutput().getStruct(), "vector");

--- a/src/test/java/com/amazonaws/sagemaker/helper/DataConversionHelperTest.java
+++ b/src/test/java/com/amazonaws/sagemaker/helper/DataConversionHelperTest.java
@@ -22,8 +22,6 @@ import com.amazonaws.sagemaker.type.BasicDataType;
 import com.amazonaws.sagemaker.type.DataStructureType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import java.io.IOException;
-import java.util.List;
 import ml.combust.mleap.core.types.ListType;
 import ml.combust.mleap.core.types.ScalarType;
 import ml.combust.mleap.core.types.TensorType;
@@ -32,8 +30,12 @@ import ml.combust.mleap.runtime.frame.DefaultLeapFrame;
 import ml.combust.mleap.runtime.javadsl.LeapFrameBuilder;
 import ml.combust.mleap.runtime.javadsl.LeapFrameBuilderSupport;
 import org.apache.commons.io.IOUtils;
+import org.apache.spark.ml.linalg.Vectors;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
 
 public class DataConversionHelperTest {
 
@@ -143,21 +145,11 @@ public class DataConversionHelperTest {
 
     @Test
     public void testCastingInputToJavaTypeList() {
-        Assert.assertEquals(Lists.newArrayList(1, 2), dataConversionHelper
-            .convertInputDataToJavaType(BasicDataType.INTEGER, DataStructureType.VECTOR,
-                Lists.newArrayList(new Integer("1"), new Integer("2"))));
 
-        Assert.assertEquals(Lists.newArrayList(1.0, 2.0), dataConversionHelper
-            .convertInputDataToJavaType(BasicDataType.FLOAT, DataStructureType.VECTOR,
-                Lists.newArrayList(new Double("1.0"), new Double("2.0"))));
-
-        Assert.assertEquals(Lists.newArrayList(1.0, 2.0), dataConversionHelper
-            .convertInputDataToJavaType(BasicDataType.DOUBLE, DataStructureType.VECTOR,
-                Lists.newArrayList(new Double("1.0"), new Double("2.0"))));
-
-        Assert.assertEquals(Lists.newArrayList(new Byte("1")), dataConversionHelper
-            .convertInputDataToJavaType(BasicDataType.BYTE, DataStructureType.VECTOR,
-                Lists.newArrayList(new Byte("1"))));
+        //Check vector struct and double type returns a Spark vector
+        Assert.assertEquals(Vectors.dense(new double[]{1.0, 2.0}),dataConversionHelper
+                .convertInputDataToJavaType(BasicDataType.DOUBLE, DataStructureType.VECTOR,
+                        Lists.newArrayList(new Double("1.0"), new Double("2.0"))));
 
         Assert.assertEquals(Lists.newArrayList(1L, 2L), dataConversionHelper
             .convertInputDataToJavaType(BasicDataType.LONG, DataStructureType.ARRAY,
@@ -173,6 +165,12 @@ public class DataConversionHelperTest {
         Assert.assertEquals(Lists.newArrayList(Boolean.valueOf("1")), dataConversionHelper
             .convertInputDataToJavaType(BasicDataType.BOOLEAN, DataStructureType.ARRAY,
                 Lists.newArrayList(Boolean.valueOf("1"))));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConvertInputToJavaTypeNonDoibleVector() {
+        dataConversionHelper
+                .convertInputDataToJavaType(BasicDataType.INTEGER, DataStructureType.VECTOR, new Integer("1"));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/resources/com/amazonaws/sagemaker/dto/complete_input.json
+++ b/src/test/resources/com/amazonaws/sagemaker/dto/complete_input.json
@@ -3,7 +3,7 @@
     "input": [
       {
         "name": "name_1",
-        "type": "int",
+        "type": "double",
         "struct": "vector"
       },
       {
@@ -23,5 +23,5 @@
       "struct": "vector"
     }
   },
-  "data": [[1, 2, 3], "C", [38.0, 24.0]]
+  "data": [[1.0, 2.0, 3.0], "C", [38.0, 24.0]]
 }


### PR DESCRIPTION
*Issue #, if available:* #3 

*Description of changes:* Fix to allow vectors as input struct. Applicable for passing input data to models like Spark Logistic Regression. Spark only supports Double types in vector type, this code enforces the double type check for inputs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
