### PR TITLE
Dummy commit to trigger a new container image build for fixing vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,9 @@ Initial release of sagemaker-sparkml-serving-container, supporting Spark major v
 ===
 
 Release of sagemaker-sparkml-serving-container, supporting Spark major version 2.3.
+
+2.4
+===
+
+Release of sagemaker-sparkml-serving-container, supporting Spark major version 2.4.
+


### PR DESCRIPTION
The SparkML-Serving-Container:2.4 contains a bunch of vulnerabilities which is blocking some customers from being able to use it. In order to resolve these, the container image needs to be rebuilt. In order to rebuild the image, I am creating a dummy commit by just adding to the change log.
However, we released SparkML-Serving-Container:2.4 a couple of months back but I realized that we never updated the ChangeLog. So I thought I'll update that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
