### PR TITLE
Update the tag for the base image for the SparkML container to always pick the latest image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u181
+FROM openjdk:8
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 


### PR DESCRIPTION
Change:
The current SparkML container image derives from a base image that is over 2 years old. This base image has a bunch of security vulnerabilities that have been addressed in subsequent images. Changing the tag of the base image to always get the latest base image.

Testing:
I verified the container by building it locally. Vulnerabilities are gone and no regressions. I was able to run all the integration and other end-to-end invocations and everything is succeeding.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
