### PR TITLE
Upgrade to Python3.6.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,47 @@
 FROM openjdk:8
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 RUN apt-get update && apt-get -y install apt-utils net-tools apt-transport-https wget curl nginx git maven
+
+RUN apt -y update
+RUN apt -y install python3.6
+
+ARG OPENSSL_VERSION=1.1.1g
+ARG PYTHON=python3
+ARG PIP=pip3
+ARG PYTHON_VERSION=3.6.13
+
+# Open-SSL
+RUN wget -q -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+ && tar -xzf openssl-${OPENSSL_VERSION}.tar.gz \
+ && cd openssl-${OPENSSL_VERSION} \
+ && ./config && make -j $(nproc) && make install \
+ && ldconfig \
+ && cd .. && rm -rf openssl-* \
+ && rmdir /usr/local/ssl/certs \
+ && ln -s /etc/ssl/certs /usr/local/ssl/certs
+
+# Install Python-3.6.13 from source
+RUN wget -q https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz \
+ && tar -xzf Python-$PYTHON_VERSION.tgz \
+ && cd Python-$PYTHON_VERSION \
+ && ./configure \
+ && make -j $(nproc) && make install \
+ && cd .. && rm -rf ../Python-$PYTHON_VERSION* \
+ && ln -s /usr/local/bin/pip3 /usr/bin/pip \
+ && ln -s /usr/local/bin/$PYTHON /usr/local/bin/python \
+ && ${PIP} --no-cache-dir install --upgrade pip
+
+# Remove other Python installations.
+RUN apt -y purge --auto-remove libpython2.7 \
+ && apt -y purge --auto-remove libpython3.7 \
+ && apt -y purge --auto-remove python3.7 \
+ && apt -y purge --auto-remove python2.7 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY / /sagemaker-sparkml-model-server
 WORKDIR /sagemaker-sparkml-model-server


### PR DESCRIPTION
openjdk:8 (the base image used by the spark container) has a dependency on python 2.7.16 which has a security vulnerability. Since openjdk:8 has not been updated and since python 2.7.16 has reached EOL, we are upgrading to python 3.6.13 which contains the fix for the vulnerability.

Upgraded to Python-3.6.13

Testing:
1. Scanned in ECR and the vulnerability is gone.
2. Exec’d into the container and the script worked as expected (no buffer overflows)
3. Ran integration tests
4. Ran manual tests that we used to deploy the last CM


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
