### PR TITLE
Versions Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
-RUN apt-get update && apt-get -y install apt-utils net-tools apt-transport-https wget curl nginx git maven
+RUN apt-get update && apt-get -y install apt-utils net-tools apt-transport-https wget curl nginx git maven libgomp1
 
 RUN apt -y update
 RUN apt -y install python3.6

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SageMaker SparkML Serving Container is primarily built on the underlying Spring 
 Supported Spark/MLeap version
 =============================
 
-Currently SageMaker SparkML Serving is powered by MLeap 0.13.0 and it is tested with Spark major version - 2.3.
+Currently SageMaker SparkML Serving is powered by MLeap 0.16.0 and it is tested with Spark major version - 2.4.
 
 Table of Contents
 =================

--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,13 @@
     </dependency>
     <dependency>
       <groupId>ml.combust.mleap</groupId>
-      <artifactId>mleap-runtime_2.11</artifactId>
-      <version>0.15.0</version>
+      <artifactId>mleap-runtime_2.12</artifactId>
+      <version>0.16.0</version>
+    </dependency>
+    <dependency>
+      <groupId>ml.combust.mleap</groupId>
+      <artifactId>mleap-tensorflow_2.12</artifactId>
+      <version>0.16.0</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-mllib-local -->
     <dependency>


### PR DESCRIPTION
*Description of changes:*
Update to use MLeap version 0.16.0 and Scala 2.12
Add Maven dependency to be able to invoke/score TensorFlow models serialized with MLeap
Add Docker library to be able to invoke/score LightGBM models serialized with MLeap

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
