### PR TITLE
Upgrades to spark 2.4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,13 +154,13 @@
     <dependency>
       <groupId>ml.combust.mleap</groupId>
       <artifactId>mleap-runtime_2.11</artifactId>
-      <version>0.15.0</version>
+      <version>0.17.0</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-mllib-local -->
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-mllib-local_2.11</artifactId>
-      <version>2.4.5</version>
+      <version>2.4.8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
* upgraded Spark to 2.4.8
* upgraded Mleap to 0.17.0 since it's the last one for Spark 2.4

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
