### PR TITLE
Fix PowerMock unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,12 @@
       <version>2.7.5</version>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.12.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
       <version>2.0.9</version>
@@ -205,6 +211,11 @@
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -306,11 +317,6 @@
       <version>1.33</version>
     </dependency>
     <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-compress</artifactId>
-        <version>1.21</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>4.0.0-rc-2</version>
@@ -379,11 +385,6 @@
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-common</artifactId>
       <version>9.4.49.v20220914</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*
Added two dependencies to enable the running PowerMock unit test. 
- mockito-core 3.12.4
- junit-vintage-engine 5.8.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
