### PR TITLE
Update pom.xml - Fix MLP dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,12 @@
       <artifactId>commons-codec</artifactId>
       <version>1.15</version>
     </dependency>
+    <!-- for MLP inference from Mleap -->
+    <dependency>
+      <groupId>com.github.fommil.netlib</groupId>
+      <artifactId>core</artifactId>
+      <version>1.1.2</version>
+    </dependency>
   </dependencies>
   <properties>
     <java.version>1.8</java.version>


### PR DESCRIPTION
Fix MLP inference by adding the dependency required by Mleap

*Issue #, if available:* AWS support case
https://support.console.aws.amazon.com/support/home?region=us-east-1#/case/?displayId=13330833201&language=en

*Description of changes:*
Fix MLP (Multi-layer Perceptron) inference error
Caused by: java.lang.ClassNotFoundException: com.github.fommil.netlib.NativeSystemBLAS
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387) ~[na:1.8.0_342]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418) ~[na:1.8.0_342]
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352) ~[na:1.8.0_342]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351) ~[na:1.8.0_342]
	at java.lang.Class.forName0(Native Method) ~[na:1.8.0_342]
	at java.lang.Class.forName(Class.java:264) ~[na:1.8.0_342]
	at com.github.fommil.netlib.BLAS.load(BLAS.java:76) ~[sparkml-serving-3.3.jar:3.3]
	at com.github.fommil.netlib.BLAS.<clinit>(BLAS.java:58) ~[sparkml-serving-3.3.jar:3.3]
	... 86 common frames omitted

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
